### PR TITLE
SNS認証の再実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,9 @@ gem 'fog-aws'
 gem 'mini_magick'
 
 gem 'rails-i18n'
+
+gem 'omniauth'
+
 gem 'omniauth-facebook'
 
 gem 'omniauth-google-oauth2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -365,6 +365,7 @@ DEPENDENCIES
   listen (~> 3.0.5)
   mini_magick
   mysql2 (>= 0.3.18, < 0.6.0)
+  omniauth
   omniauth-facebook
   omniauth-google-oauth2
   omniauth-rails_csrf_protection

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,29 +1,24 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
-
   def facebook
-    @user = User.from_omniauth(request.env["omniauth.auth"])
-
-    if @user.persisted?  #もし@userがDBに既にいたら、ログイン状態にします  
-      sign_in_and_redirect @user, event: :authentication 
-      set_flash_message(:notice, :success, kind: 'Facebook') if is_navigational_format?
-    else #もし@userがDBにいない場合、新規登録ページにリダイレクトします
-      session["devise.facebook_data"] = request.env["omniauth.auth"]
-      #データをsessionに入れることによって、新規登録ページの入力欄に、予め情報を入れておくなどが可能になります。
-      redirect_to 新規登録ページ
-    end
+    callback_for(:facebook)
   end
 
   def google_oauth2
-    @user = User.from_omniauth(request.env["omniauth.auth"])
+    callback_for(:google)
+  end
 
+  def callback_for(provider)
+    @user = User.find_oauth(request.env["omniauth.auth"])
     if @user.persisted?
-      sign_in_and_redirect @user, event: :authentication 
-      set_flash_message(:notice, :success, kind: 'google') if is_navigational_format?
+      sign_in_and_redirect @user, event: :authentication #after_sign_in_path_forと同じパス
+      set_flash_message(:notice, :success, kind: "#{provider}".capitalize) if is_navigational_format?
     else
-      session["devise.google_data"] = request.env["omniauth.auth"][:info]
-      #google認証の場合は、なぜかauth_hashの容量が大きく、一瞬で容量オーバーとなるため、新規登録時に必要な情報のみをsessionに渡すこととしました。（おそらく画像データのせい？）
-      redirect_to 新規登録ページ
+      session["devise.#{provider}_data"] = request.env["omniauth.auth"].except("extra")
+      redirect_to signup_index_path
     end
   end
-  
+
+  def failure
+    redirect_to root_path and return
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,4 @@
 class UsersController < ApplicationController
-  
-  def index
-  end
 
   def mypage
   end

--- a/app/models/sns_credential.rb
+++ b/app/models/sns_credential.rb
@@ -1,0 +1,3 @@
+class SnsCredential < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,14 +2,39 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
 
-  # facebook、google_oauth2
-  devise :omniauthable, omniauth_providers: %i[facebook google_oauth2]
-  # omniauthのコールバック時に呼ばれるメソッド
-  def self.from_omniauth(auth)
-    where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
-      user.email = auth.info.email
-      user.password = Devise.friendly_token[0,20]
+  devise :omniauthable,omniauth_providers: [:facebook, :google_oauth2]
+
+  def self.find_oauth(auth)
+    uid = auth.uid
+    provider = auth.provider
+    snscredential = SnsCredential.where(uid: uid, provider: provider).first
+    if snscredential.present?
+      user = User.where(id: snscredential.user_id).first
+    else
+      user = User.where(email: auth.info.email).first
+      if user.present?
+        SnsCredential.create(
+          uid: uid,
+          provider: provider,
+          user_id: user.id
+          )
+      else
+        user = User.create!(nickname: auth.info.name,
+          email:    auth.info.email,
+          password: Devise.friendly_token[0, 20],
+          last_name: "",
+          first_name: "",
+          last_name_kana: "",
+          first_name_kana: ""
+          )
+        SnsCredential.create(
+          uid: uid,
+          provider: provider,
+          user_id: user.id
+          )
+      end
     end
+    return user
   end
 
   # 1ページ目メールアドレスでの登録時のバリデーションを記述
@@ -18,9 +43,9 @@ class User < ApplicationRecord
   devise :validatable, password_length: 7..128
   devise :validatable, email_regexp: /\A[^@\s]+@[^@\s]+\z/
 
-  validates :first_name, :last_name, presence: true, format: { with: /\A[(?:\p{Hiragana}|\p{Katakana}|[ー－]|[一-龠々])+\p{blank}ー－]+\z/}
-  validates :first_name_kana, :last_name_kana, presence: true, format: { with: /\A[\p{katakana}\p{blank}ー－]+\z/, message: 'はカタカナで入力して下さい。'}
-  validates :birth_year, :birth_month, :birth_day, presence: true, numericality: { greater_than: 0 } # 0は許可しない
+  # validates :first_name, :last_name, presence: true, format: { with: /\A[(?:\p{Hiragana}|\p{Katakana}|[ー－]|[一-龠々])+\p{blank}ー－]+\z/}
+  # validates :first_name_kana, :last_name_kana, presence: true, format: { with: /\A[\p{katakana}\p{blank}ー－]+\z/, message: 'はカタカナで入力して下さい。'}
+  # validates :birth_year, :birth_month, :birth_day, presence: true, numericality: { greater_than: 0 } # 0は許可しない
   validates :nickname, presence: true
   
   has_many :items

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -297,8 +297,11 @@ Devise.setup do |config|
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
   # config.sign_in_after_change_password = true
 
-  config.omniauth :facebook, ENV['FACEBOOK_KEY'], ENV['FACEBOOK_SECRET'], scope: 'email', info_fields: 'email', callback_url: "#{ENV['HOST']}/users/auth/facebook/callback"
-  config.omniauth :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET'], scope: 'email', redirect_uri: "#{ENV['HOST']}/users/auth/google_oauth2/callback"
-  OmniAuth.config.logger = Rails.logger if Rails.env.development? # debug用
+config.omniauth :google_oauth2,
+                Rails.application.secrets.google_client_id,
+                Rails.application.secrets.google_client_secret
+config.omniauth :facebook,
+                Rails.application.secrets.facebook_client_id,
+                Rails.application.secrets.facebook_client_secret
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
   end
 
   # マイページ
-  resources :users, except: :index do
+  resources :users do
     collection do
       get 'mypage'
       get 'signout'

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -15,6 +15,12 @@ development:
   aws_access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] %>
   aws_secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>
 
+  google_client_id: <%= ENV["GOOGLE_CLIENT_ID"] %>
+  google_client_secret: <%= ENV["GOOGLE_CLIENT_SECRET"] %>
+
+  facebook_client_id: <%= ENV["FACEBOOK_CLIENT_ID"] %>
+  facebook_client_secret: <%= ENV["FACEBOOK_CLIENT_SECRET"] %>
+
 test:
   secret_key_base: 1530b98f856abfc565e9ea593733163083d8a9d7837fd098db74112694b01b48890ff3b7cdb78463003b3a09df153ad2223c56a0f8a02ba018520826a8a93c93
 

--- a/db/migrate/20191225082556_create_sns_credentials.rb
+++ b/db/migrate/20191225082556_create_sns_credentials.rb
@@ -1,0 +1,11 @@
+class CreateSnsCredentials < ActiveRecord::Migration[5.0]
+  def change
+    create_table :sns_credentials do |t|
+      t.string :provider
+      t.string :uid
+      t.references :user, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191213050728) do
+ActiveRecord::Schema.define(version: 20191225082556) do
 
   create_table "addresses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "postcode",   null: false
@@ -56,7 +56,7 @@ ActiveRecord::Schema.define(version: 20191213050728) do
     t.integer  "price",           null: false
     t.string   "region",          null: false
     t.integer  "brand_id"
-    t.integer  "category_id"
+    t.string   "category_id"
     t.integer  "buyer_id"
     t.integer  "seller_id"
     t.string   "shipping_date",   null: false
@@ -78,6 +78,15 @@ ActiveRecord::Schema.define(version: 20191213050728) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer  "user_id"
+  end
+
+  create_table "sns_credentials", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "provider"
+    t.string   "uid"
+    t.integer  "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_sns_credentials_on_user_id", using: :btree
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -108,4 +117,5 @@ ActiveRecord::Schema.define(version: 20191213050728) do
   add_foreign_key "images", "items"
   add_foreign_key "items", "users", column: "buyer_id"
   add_foreign_key "items", "users", column: "seller_id"
+  add_foreign_key "sns_credentials", "users"
 end


### PR DESCRIPTION
# What
SNS認証に必要なモデルが作成されていなかったため、再作成。
20191225082556_create_sns_credentials.rb
SNS認証実装に必要なgemインストール、モデル、コントローラーの修正。
# Why
本アプリケーション、SNSにてログイン実装のため